### PR TITLE
Fix issue in incl_horizontal_progress.xml

### DIFF
--- a/BiglyBT/src/main/res/layout/incl_horizontal_progress.xml
+++ b/BiglyBT/src/main/res/layout/incl_horizontal_progress.xml
@@ -24,6 +24,7 @@
 	android:layout_height="wrap_content"
 	android:layout_marginTop="-6dp"
 	android:indeterminateTint="?colorPrimary"
+	android:indeterminateTintMode="src_in"
 	android:progressTint="?colorPrimary"
 	android:indeterminateOnly="true"
 	android:max="10000"


### PR DESCRIPTION
Hi,

I have found in incl_horizontal_progress.xml, you did not set `android:indeterminateTintMode="src_in"`, which can cause the color of ProgressBar not consistent in API Level < 23. This pull request help you fix this problem.

Wish it can help you. Thanks