### PR TITLE
Add new permission for Android 11

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 	<uses-sdk tools:overrideLibrary="androidx.leanback,androidx.leanback.preference,mldht"/>
 
 	<uses-permission android:name="android.permission.INTERNET"/>
+        <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.READ_MEDIA_STORAGE"/>


### PR DESCRIPTION
## Issue

I just updated my nvidia shield and i'm encountering an issue when trying to write to the SDCard. But I have some clue that may help to solve the issue for Android 11

For other apps like VLC or Solid Explorer I can manually go to the android permission setting for the app and set file access to "always authorize" instead of the default "Authorize if the app is opened" and it fixes the issue (I can write and read the SD card from these apps)

When I try to edit the permissions for biglyBT on android I don't have the ability to set "always authorize". A permission may be missing for biglybt (I can do a capture but my interface is in french so i'm not sure it would help)

I'm not an Android dev but I looked what changed for other apps and some seems to refer to a new permission MANAGE_EXTERNAL_STORAGE https://github.com/videolan/vlc-android/commit/a1fa4a840359048e46b390889dc476fd1b63f55c

I hope it solves the issue

## Source

- [Android documentation](https://developer.android.com/training/data-storage/manage-all-files)
- [Android Support page](https://support.google.com/googleplay/android-developer/answer/10467955?hl=en)

## Improvment

I'm not an android dev so I can't help further but a popup could be set to ask for the permission from within the App. 